### PR TITLE
Add special case for handling ChangeNotifiers

### DIFF
--- a/packages/context_ref/lib/src/value_provider.dart
+++ b/packages/context_ref/lib/src/value_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 
 @internal
@@ -34,7 +35,11 @@ class ValueProvider<T> {
       if (_disposer != null) {
         _disposer!(value);
       } else {
-        _tryDispose(value);
+        if (value case ChangeNotifier cn) {
+          cn.dispose();
+        } else {
+          _tryDispose(value);
+        }
       }
     } finally {
       _valueWrapper = null;


### PR DESCRIPTION
Since this package is most likely to be used with `ChangeNotifier`s and `ValueNotifier`s; it's safer and more performant to just do a type check to dispose them without resorting to dynamic dispatch.