### PR TITLE
[context_watch] Removes the rxdart dependency

### DIFF
--- a/packages/context_watch/lib/src/watchers/stream_context_watcher.dart
+++ b/packages/context_watch/lib/src/watchers/stream_context_watcher.dart
@@ -70,8 +70,8 @@ AsyncSnapshot<T> _initialSnapshot<T>(Stream stream) {
   return AsyncSnapshot<T>.nothing().inState(ConnectionState.waiting);
 }
 
-/// Mimics the interface of a `ValueStream` from `rx_dart` without having an
-/// actual dependency on the [rx_dart] package.
+/// Mimics the interface of a `ValueStream` from `rxdart` without having an
+/// actual dependency on the [rxdart] package.
 class SupportValueStream<T> {
   final Stream<T> stream;
 

--- a/packages/context_watch/lib/src/watchers/stream_context_watcher.dart
+++ b/packages/context_watch/lib/src/watchers/stream_context_watcher.dart
@@ -72,15 +72,48 @@ AsyncSnapshot<T> _initialSnapshot<T>(Stream stream) {
 
 /// Mimics the interface of a `ValueStream` from `rxdart` without having an
 /// actual dependency on the [rxdart] package.
-class SupportValueStream<T> {
+///
+/// Additionally it supports the `ValueStream` from
+/// rxdart:0.26.0 https://github.com/ReactiveX/rxdart/releases/tag/0.26.0 (introduced)
+/// rxdart:0.27.0 https://github.com/ReactiveX/rxdart/releases/tag/0.27.0 (breaking)
+/// rxdart:0.28.0 https://github.com/ReactiveX/rxdart/releases/tag/0.28.0 (non-breaking)
+abstract class SupportValueStream<T> {
+  /// Casts a [Stream] to a [_SupportValueStream] if it passed the duck test
+  static SupportValueStream<T>? cast<T>(Stream<T> stream) {
+    final vs27 = SupportValueStream27to28.cast(stream);
+    if (vs27 != null) {
+      return vs27;
+    }
+
+    final vs26 = SupportValueStream26.cast(stream);
+    if (vs26 != null) {
+      return vs26;
+    }
+    return null;
+  }
+
+  bool get hasValue;
+  T get value;
+  bool get hasError;
+  Object get error;
+  StackTrace? get stackTrace;
+}
+
+/// rxdart:0.27.x ValueStream
+/// https://github.com/ReactiveX/rxdart/blob/61512993d0ba3852f68537cf2e0b2a167d8178f8/lib/src/streams/value_stream.dart#L2
+/// rxdart:0.28.x ValueStream
+/// https://github.com/ReactiveX/rxdart/blob/0.28.0/packages/rxdart/lib/src/streams/value_stream.dart#L5
+///
+/// Both are identical based on our SupportValueStream interface
+class SupportValueStream27to28<T> implements SupportValueStream<T> {
   final Stream<T> stream;
 
   @visibleForTesting
-  SupportValueStream(this.stream);
+  SupportValueStream27to28(this.stream);
 
   /// Casts a [Stream] to a [_SupportValueStream] if it passed the duck test
-  static SupportValueStream<T>? cast<T>(Stream<T> stream) {
-    final valueStream = SupportValueStream(stream);
+  static SupportValueStream27to28<T>? cast<T>(Stream<T> stream) {
+    final valueStream = SupportValueStream27to28(stream);
     try {
       // Duck test: If it looks like a duck, swims like a duck, and quacks like a duck, then it probably is a duck.
       // try to access all methods that make a ValueStream a ValueStream
@@ -98,6 +131,7 @@ class SupportValueStream<T> {
     }
   }
 
+  @override
   bool get hasValue {
     final dynamic dynamicStream = stream;
     final result = dynamicStream.hasValue;
@@ -108,6 +142,7 @@ class SupportValueStream<T> {
         'Stream.hasValue does not return a boolean, but ${result.runtimeType}');
   }
 
+  @override
   T get value {
     final dynamic dynamicStream = stream;
     final result = dynamicStream.value;
@@ -117,6 +152,7 @@ class SupportValueStream<T> {
     throw StateError('Stream.value is of type ${result.runtimeType}, not $T');
   }
 
+  @override
   bool get hasError {
     final dynamic dynamicStream = stream;
     final result = dynamicStream.hasError;
@@ -127,6 +163,7 @@ class SupportValueStream<T> {
         'Stream.hasError does not return a boolean, but ${result.runtimeType}');
   }
 
+  @override
   Object get error {
     final dynamic dynamicStream = stream;
     final result = dynamicStream.error;
@@ -137,6 +174,7 @@ class SupportValueStream<T> {
         'Stream.error is of type ${result.runtimeType}, not Object');
   }
 
+  @override
   StackTrace? get stackTrace {
     final dynamic dynamicStream = stream;
     final result = dynamicStream.stackTrace;
@@ -145,6 +183,93 @@ class SupportValueStream<T> {
     }
     throw StateError(
         'Stream.stackTrace is of type ${result.runtimeType}, not StackTrace');
+  }
+}
+
+/// rxdart:0.26.x ValueStream
+/// https://github.com/ReactiveX/rxdart/blob/0.26.0/lib/src/streams/value_stream.dart#L5
+class SupportValueStream26<T> implements SupportValueStream<T> {
+  final Stream<T> stream;
+
+  @visibleForTesting
+  SupportValueStream26(this.stream);
+
+  /// Tries to casts a [Stream] to `ValueStream` from rxdart:0.26.0 if it passed the duck test
+  static SupportValueStream26<T>? cast<T>(Stream<T> stream) {
+    final valueStream = SupportValueStream26(stream);
+    try {
+      // Duck test: If it looks like a duck, swims like a duck, and quacks like a duck, then it probably is a duck.
+      // try to access all methods that make a ValueStream a ValueStream
+      valueStream.valueWrapper;
+      valueStream.errorAndStackTrace;
+      // supports all used methods/getters, so it is a ValueStream
+      return valueStream;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  dynamic /*ValueWrapper?*/ get valueWrapper {
+    final dynamic dynamicStream = stream;
+    final dynamic wrapper = dynamicStream.valueWrapper;
+    if (wrapper == null) {
+      return wrapper;
+    }
+    final value = wrapper.value;
+    if (value is T) {
+      return wrapper;
+    }
+    throw StateError(
+        'Stream.valueWrapper.value is of type ${value.runtimeType}, not $T');
+  }
+
+  dynamic /*ErrorAndStackTrace?*/ get errorAndStackTrace {
+    final dynamic dynamicStream = stream;
+    final union = dynamicStream.errorAndStackTrace;
+    if (union == null) {
+      return union;
+    }
+    final error = union.error;
+    if (error is! Object) {
+      throw StateError(
+          'Stream.errorAndStackTrace.error is of type ${error.runtimeType}, not Object');
+    }
+    final stackTrace = union.stackTrace;
+    if (stackTrace is! StackTrace?) {
+      throw StateError(
+          'Stream.errorAndStackTrace.stackTrace is of type ${stackTrace.runtimeType}, not StackTrace?');
+    }
+    return union;
+  }
+
+  @override
+  bool get hasValue {
+    // match https://github.com/ReactiveX/rxdart/blob/0.26.0/lib/src/streams/value_stream.dart#L20
+    return valueWrapper != null;
+  }
+
+  @override
+  T get value {
+    // match https://github.com/ReactiveX/rxdart/blob/0.26.0/lib/src/streams/value_stream.dart#L23
+    return valueWrapper?.value;
+  }
+
+  @override
+  bool get hasError {
+    // match https://github.com/ReactiveX/rxdart/blob/0.26.0/lib/src/streams/value_stream.dart#L43
+    return errorAndStackTrace != null;
+  }
+
+  @override
+  Object get error {
+    // match https://github.com/ReactiveX/rxdart/blob/0.26.0/lib/src/streams/value_stream.dart#L46
+    return errorAndStackTrace?.error;
+  }
+
+  @override
+  StackTrace? get stackTrace {
+    // access https://github.com/ReactiveX/rxdart/blob/0.26.0/lib/src/utils/error_and_stacktrace.dart#L8
+    return errorAndStackTrace?.stackTrace;
   }
 }
 

--- a/packages/context_watch/pubspec.yaml
+++ b/packages/context_watch/pubspec.yaml
@@ -24,6 +24,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.1
-  rxdart: ^0.27.7
+  rxdart: ">=0.26.0 <0.29.0"
 
 flutter:

--- a/packages/context_watch/pubspec.yaml
+++ b/packages/context_watch/pubspec.yaml
@@ -16,7 +16,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.27.7
   async_listenable: ^1.0.1
   meta: ^1.9.1
   context_watch_base: ^3.1.1
@@ -25,5 +24,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.1
+  rxdart: ^0.27.7
 
 flutter:

--- a/packages/context_watch/test/stream_watch_test.dart
+++ b/packages/context_watch/test/stream_watch_test.dart
@@ -161,56 +161,103 @@ void main() {
   );
 
   group('SupportValueStream', () {
-    test('recognizes rxdart ValueStream', () {
+    test('recognizes latest rxdart ValueStream', () {
+      // uses whatever rxdart version is currently available
       final subject = BehaviorSubject<int>();
+      subject.hasValue;
       // ignore: unnecessary_type_check
       expect(subject is ValueStream<int>, isTrue);
       final stream = SupportValueStream.cast(subject.stream);
       expect(stream, isNotNull);
     });
 
-    test('hasValue does not exist', () {
-      final stream = SupportValueStream(_AnyOtherStream());
-      expect(() => stream.hasValue, throwsNoSuchMethodError);
+    group('rxdart 0.27.x/0.28.x', () {
+      test('hasValue does not exist', () {
+        final stream = SupportValueStream27to28(_AnyOtherStream());
+        expect(() => stream.hasValue, throwsNoSuchMethodError);
+      });
+      test('hasValue wrong type', () {
+        final stream =
+            SupportValueStream27to28(_SupportValueStream_hasValueWrongType());
+        expect(() => stream.hasValue, throwsStateError);
+      });
+      test('value does not exist', () {
+        final stream = SupportValueStream27to28(_AnyOtherStream());
+        expect(() => stream.value, throwsNoSuchMethodError);
+      });
+      test('value wrong type', () {
+        final stream =
+            SupportValueStream27to28(_SupportValueStream_valueWrongType());
+        expect(() => stream.value, throwsStateError);
+      });
+      test('hasError does not exist', () {
+        final stream = SupportValueStream27to28(_AnyOtherStream());
+        expect(() => stream.hasError, throwsNoSuchMethodError);
+      });
+      test('hasError wrong type', () {
+        final stream =
+            SupportValueStream27to28(_SupportValueStream_hasErrorWrongType());
+        expect(() => stream.hasError, throwsStateError);
+      });
+      test('error does not exist', () {
+        final stream = SupportValueStream27to28(_AnyOtherStream());
+        expect(() => stream.error, throwsNoSuchMethodError);
+      });
+      test('error wrong type', () {
+        final stream =
+            SupportValueStream27to28(_SupportValueStream_errorWrongType());
+        expect(() => stream.error, throwsStateError);
+      });
+      test('stackTrace does not exist', () {
+        final stream = SupportValueStream27to28(_AnyOtherStream());
+        expect(() => stream.stackTrace, throwsNoSuchMethodError);
+      });
+      test('stackTrace wrong type', () {
+        final stream =
+            SupportValueStream27to28(_SupportValueStream_stacktraceWrongType());
+        expect(() => stream.stackTrace, throwsStateError);
+      });
     });
-    test('hasValue wrong type', () {
-      final stream =
-          SupportValueStream(_SupportValueStream_hasValueWrongType());
-      expect(() => stream.hasValue, throwsStateError);
-    });
-    test('value does not exist', () {
-      final stream = SupportValueStream(_AnyOtherStream());
-      expect(() => stream.value, throwsNoSuchMethodError);
-    });
-    test('value wrong type', () {
-      final stream = SupportValueStream(_SupportValueStream_valueWrongType());
-      expect(() => stream.value, throwsStateError);
-    });
-    test('hasError does not exist', () {
-      final stream = SupportValueStream(_AnyOtherStream());
-      expect(() => stream.hasError, throwsNoSuchMethodError);
-    });
-    test('hasError wrong type', () {
-      final stream =
-          SupportValueStream(_SupportValueStream_hasErrorWrongType());
-      expect(() => stream.hasError, throwsStateError);
-    });
-    test('error does not exist', () {
-      final stream = SupportValueStream(_AnyOtherStream());
-      expect(() => stream.error, throwsNoSuchMethodError);
-    });
-    test('error wrong type', () {
-      final stream = SupportValueStream(_SupportValueStream_errorWrongType());
-      expect(() => stream.error, throwsStateError);
-    });
-    test('stackTrace does not exist', () {
-      final stream = SupportValueStream(_AnyOtherStream());
-      expect(() => stream.stackTrace, throwsNoSuchMethodError);
-    });
-    test('stackTrace wrong type', () {
-      final stream =
-          SupportValueStream(_SupportValueStream_stacktraceWrongType());
-      expect(() => stream.stackTrace, throwsStateError);
+
+    group('rxdart 0.26.x', () {
+      test('valueWrapper does not exist', () {
+        final stream = SupportValueStream26(_AnyOtherStream());
+        expect(() => stream.valueWrapper, throwsNoSuchMethodError);
+      });
+      test('valueWrapper wrong type', () {
+        final stream =
+            SupportValueStream26(_SupportValueStream_valueWrapperWrongType());
+        expect(() => stream.valueWrapper, throwsNoSuchMethodError);
+      });
+      test('valueWrapper.value does not exist', () {
+        final stream =
+            SupportValueStream26(_SupportValueStream_valueWrapperMissesValue());
+        expect(() => stream.valueWrapper, throwsNoSuchMethodError);
+      });
+      test('valueWrapper.value wrong type', () {
+        final stream = SupportValueStream26(
+            _SupportValueStream_valueWrapperValueWrongType());
+        expect(() => stream.valueWrapper, throwsStateError);
+      });
+      test('errorAndStackTrace does not exist', () {
+        final stream = SupportValueStream26(_AnyOtherStream());
+        expect(() => stream.errorAndStackTrace, throwsNoSuchMethodError);
+      });
+      test('errorAndStackTrace wrong type', () {
+        final stream = SupportValueStream26(
+            _SupportValueStream_errorAndStackTraceWrongType());
+        expect(() => stream.errorAndStackTrace, throwsNoSuchMethodError);
+      });
+      test('errorAndStackTrace.stackTrace wrong type', () {
+        final stream = SupportValueStream26(
+            _SupportValueStream_errorAndStackTrace_StackTraceWrongType());
+        expect(() => stream.errorAndStackTrace, throwsStateError);
+      });
+      test('errorAndStackTrace.error wrong type', () {
+        final stream = SupportValueStream26(
+            _SupportValueStream_errorAndStackTrace_ErrorWrongType());
+        expect(() => stream.errorAndStackTrace, throwsStateError);
+      });
     });
   });
 }
@@ -236,6 +283,51 @@ class _SupportValueStream_errorWrongType<T> extends _UnimplementedStream<T> {
 class _SupportValueStream_stacktraceWrongType<T>
     extends _UnimplementedStream<T> {
   String get stackTrace => 'no'; // expects StackTrace?
+}
+
+class _SupportValueStream_valueWrapperWrongType<T>
+    extends _UnimplementedStream<T> {
+  String get valueWrapper => 'no'; // expects ValueWrapper
+}
+
+class _SupportValueStream_valueWrapperMissesValue<T>
+    extends _UnimplementedStream<T> {
+  dynamic get valueWrapper => Object(); // expects ValueWrapper with .value
+}
+
+class _SupportValueStream_valueWrapperValueWrongType
+    extends _UnimplementedStream<int> {
+  dynamic get valueWrapper =>
+      _ValueWrapper_ValueWrongType(); // expects ValueWrapper
+}
+
+class _ValueWrapper_ValueWrongType {
+  String get value => 'no'; // expects int
+}
+
+class _SupportValueStream_errorAndStackTraceWrongType<T>
+    extends _UnimplementedStream<T> {
+  String get errorAndStackTrace => 'no'; // expects ErrorAndStackTrace
+}
+
+class _SupportValueStream_errorAndStackTrace_ErrorWrongType<T>
+    extends _UnimplementedStream<T> {
+  dynamic get errorAndStackTrace => _ErrorAndStackTrace_ErrorWrongType();
+}
+
+class _ErrorAndStackTrace_ErrorWrongType {
+  Object? get error => null; // expects Object
+  StackTrace get stackTrace => StackTrace.current;
+}
+
+class _SupportValueStream_errorAndStackTrace_StackTraceWrongType<T>
+    extends _UnimplementedStream<T> {
+  dynamic get errorAndStackTrace => _ErrorAndStackTrace_StackTraceWrongType();
+}
+
+class _ErrorAndStackTrace_StackTraceWrongType {
+  Object get error => Object();
+  String get stackTrace => 'no'; // expects StackTrace
 }
 
 class _UnimplementedStream<T> extends Stream<T> {

--- a/packages/context_watch/test/stream_watch_test.dart
+++ b/packages/context_watch/test/stream_watch_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: camel_case_types
+
 import 'dart:async';
 
 import 'package:context_watch/context_watch.dart';
@@ -157,4 +159,89 @@ void main() {
       ]);
     },
   );
+
+  group('SupportValueStream', () {
+    test('recognizes rx_dart ValueStream', () {
+      final subject = BehaviorSubject<int>();
+      // ignore: unnecessary_type_check
+      expect(subject is ValueStream<int>, isTrue);
+      final stream = SupportValueStream.cast(subject.stream);
+      expect(stream, isNotNull);
+    });
+
+    test('hasValue does not exist', () {
+      final stream = SupportValueStream(_AnyOtherStream());
+      expect(() => stream.hasValue, throwsNoSuchMethodError);
+    });
+    test('hasValue wrong type', () {
+      final stream =
+          SupportValueStream(_SupportValueStream_hasValueWrongType());
+      expect(() => stream.hasValue, throwsStateError);
+    });
+    test('value does not exist', () {
+      final stream = SupportValueStream(_AnyOtherStream());
+      expect(() => stream.value, throwsNoSuchMethodError);
+    });
+    test('value wrong type', () {
+      final stream = SupportValueStream(_SupportValueStream_valueWrongType());
+      expect(() => stream.value, throwsStateError);
+    });
+    test('hasError does not exist', () {
+      final stream = SupportValueStream(_AnyOtherStream());
+      expect(() => stream.hasError, throwsNoSuchMethodError);
+    });
+    test('hasError wrong type', () {
+      final stream =
+          SupportValueStream(_SupportValueStream_hasErrorWrongType());
+      expect(() => stream.hasError, throwsStateError);
+    });
+    test('error does not exist', () {
+      final stream = SupportValueStream(_AnyOtherStream());
+      expect(() => stream.error, throwsNoSuchMethodError);
+    });
+    test('error wrong type', () {
+      final stream = SupportValueStream(_SupportValueStream_errorWrongType());
+      expect(() => stream.error, throwsStateError);
+    });
+    test('stackTrace does not exist', () {
+      final stream = SupportValueStream(_AnyOtherStream());
+      expect(() => stream.stackTrace, throwsNoSuchMethodError);
+    });
+    test('stackTrace wrong type', () {
+      final stream =
+          SupportValueStream(_SupportValueStream_stacktraceWrongType());
+      expect(() => stream.stackTrace, throwsStateError);
+    });
+  });
+}
+
+class _AnyOtherStream<T> extends _UnimplementedStream<T> {}
+
+class _SupportValueStream_hasValueWrongType<T> extends _UnimplementedStream<T> {
+  String get hasValue => 'no'; // expects bool
+}
+
+class _SupportValueStream_valueWrongType extends _UnimplementedStream<int> {
+  String get value => 'no'; // expects T (int)
+}
+
+class _SupportValueStream_hasErrorWrongType<T> extends _UnimplementedStream<T> {
+  String get hasError => 'no'; // expects bool
+}
+
+class _SupportValueStream_errorWrongType<T> extends _UnimplementedStream<T> {
+  Object? get error => null; // expects Object
+}
+
+class _SupportValueStream_stacktraceWrongType<T>
+    extends _UnimplementedStream<T> {
+  String get stackTrace => 'no'; // expects StackTrace?
+}
+
+class _UnimplementedStream<T> extends Stream<T> {
+  @override
+  StreamSubscription<T> listen(void Function(T event)? onData,
+      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    throw UnimplementedError();
+  }
 }

--- a/packages/context_watch/test/stream_watch_test.dart
+++ b/packages/context_watch/test/stream_watch_test.dart
@@ -161,7 +161,7 @@ void main() {
   );
 
   group('SupportValueStream', () {
-    test('recognizes rx_dart ValueStream', () {
+    test('recognizes rxdart ValueStream', () {
       final subject = BehaviorSubject<int>();
       // ignore: unnecessary_type_check
       expect(subject is ValueStream<int>, isTrue);


### PR DESCRIPTION
I ran into conflicts with the rxdart dependency across multiple projects. It's very common. Usually, I avoid any package depending on rxdart because of so many breaking changes in the past.

This PR entirely removes the rxdart dependency and while making it compatible with even more versions:
compatability before: `rxdart: ">=0.27.7 <0.28.0`
compatability now: `rxdart: ">=0.26.0 <0.29.0"`

![Screen-Shot-2024-07-21-19-12-43 46](https://github.com/user-attachments/assets/4f107699-2744-42de-ad86-e3386a45992a)

The only thing I had to replace was the usage of `ValueStream`. It was fairly easy using `dynamic` checks. Similar to `tryDispose` in `context_ref`. 

`rxdart: 0.26.0` is old, but it was easy to add support. Hence I added it right away.